### PR TITLE
Add error message for exceptions.

### DIFF
--- a/cif-validator/compute/__init__.py
+++ b/cif-validator/compute/__init__.py
@@ -41,6 +41,8 @@ def validate():
             data, err_count, err_msg = pycodcif.parse('test.cif')
             data[0]['err_count'] = err_count
             data[0]['err_msg'] = err_msg
-        except:
-            return 'Please submit a CIF file.'
+        except Exception as e:
+            e = str(e).replace("\n", " ")
+            error = 'Failed to parse the cif file: ' + e
+            data = [{'err_msg': error, }]
         return json.dumps(data)


### PR DESCRIPTION
Here is an example error message:
`{"err_msg": "Failed to parse the cif file: mod_wsgi: test.cif(16,1) data_ADH041: ERROR, incorrect CIF syntax:  lol  ^ "}`